### PR TITLE
Fix memory leak for cs1010_read_double

### DIFF
--- a/src/cs1010.c
+++ b/src/cs1010.c
@@ -180,6 +180,7 @@ double cs1010_read_double()
     fprintf(stderr, "cs1010_read_double: reach the end without null/newline. '%s' remains\n", buff);
     return DBL_MAX;
   }
+  free(buff);
   return number;
 }
 


### PR DESCRIPTION
To reproduce memory leak

Code:
```c
#include "cs1010.h"

int main() {
  printf("Inputted float: %lf", cs1010_read_double());
  return 0;
}
```

```
user@pe113:~/$ clang -I libcs1010/include -L libcs1010/lib test.c -o test -lcs1010
user@pe113:~/$ valgrind ./test
==1031== Memcheck, a memory error detector
==1031== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1031== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==1031== Command: ./t2
==1031== 
2.0
Inputted float: 2.000000==1031== 
==1031== HEAP SUMMARY:
==1031==     in use at exit: 5 bytes in 1 blocks
==1031==   total heap usage: 4 allocs, 3 frees, 2,054 bytes allocated
==1031== 
==1031== LEAK SUMMARY:
==1031==    definitely lost: 5 bytes in 1 blocks
==1031==    indirectly lost: 0 bytes in 0 blocks
==1031==      possibly lost: 0 bytes in 0 blocks
==1031==    still reachable: 0 bytes in 0 blocks
==1031==         suppressed: 0 bytes in 0 blocks
==1031== Rerun with --leak-check=full to see details of leaked memory
==1031== 
==1031== For counts of detected and suppressed errors, rerun with: -v
==1031== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```