### PR TITLE
Fix strict-prototypes warning

### DIFF
--- a/src/cs1010.c
+++ b/src/cs1010.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "cs1010.h"
 
 #define BUF_SIZE 32
 static


### PR DESCRIPTION
```
clang -c @compile_flags.txt -Iinclude   -c -o src/cs1010.o src/cs1010.c
src/cs1010.c:52:23: warning: this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]
char* cs1010_read_word()
                      ^
src/cs1010.c:94:22: warning: this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]
long cs1010_read_long()
                     ^
src/cs1010.c:139:23: warning: this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]
char* cs1010_read_line()
                      ^
src/cs1010.c:156:26: warning: this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]
double cs1010_read_double()
                         ^
src/cs1010.c:342:25: warning: this old-style function definition is not preceded by a prototype [-Wstrict-prototypes]
void cs1010_clear_screen()
                        ^
5 warnings generated.
```
```
clang --version
clang version 12.0.0
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```