### PR TITLE
Fix non-`const` prototype of `cs1010_print*_string`

### DIFF
--- a/include/cs1010.h
+++ b/include/cs1010.h
@@ -19,11 +19,11 @@ char** cs1010_read_word_array(long how_many);
 
 void cs1010_println_double(double d);
 void cs1010_println_long(long d);
-void cs1010_println_string(char *s);
+void cs1010_println_string(const char *s);
 
 void cs1010_print_double(double d);
 void cs1010_print_long(long d);
-void cs1010_print_string(char *s);
+void cs1010_print_string(const char *s);
 
 void cs1010_clear_screen(void);
 

--- a/src/cs1010.c
+++ b/src/cs1010.c
@@ -323,7 +323,7 @@ void cs1010_println_long(long d)
 /**
  * @brief Print a string to standard output.
  */
-void cs1010_print_string(char *s)
+void cs1010_print_string(const char *s)
 {
   printf("%s", s);
 }
@@ -331,7 +331,7 @@ void cs1010_print_string(char *s)
 /**
  * @brief Print a string to standard output, followed by a newline.
  */
-void cs1010_println_string(char *s)
+void cs1010_println_string(const char *s)
 {
   printf("%s\n", s);
 }


### PR DESCRIPTION
These functions do not modify the underlying string, thus should be
qualified with `const`. This allows passing in a string literal or const
pointer for printing without compiler errors or typecasting.

[Ref.](https://piazza.com/class/kdgunoizhic105?cid=572)